### PR TITLE
Update API doc links

### DIFF
--- a/book/src/03_2_blinky.md
+++ b/book/src/03_2_blinky.md
@@ -41,7 +41,7 @@ We also see that the HAL offers a way to delay execution.
 
 [ESP32-C3-DevKit-RUST-1]:  https://github.com/esp-rs/esp-rust-board
 [LED connected to GPIO 7]: https://github.com/esp-rs/esp-rust-board#pin-layout
-[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
+[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
 [toogle]: https://docs.rs/embedded-hal/0.2.7/embedded_hal/digital/v2/trait.ToggleableOutputPin.html#tymethod.toggle
 [delay-ms]: https://docs.rs/embedded-hal/0.2.7/embedded_hal/blocking/delay/trait.DelayMs.html#tymethod.delay_ms
 

--- a/book/src/03_3_button.md
+++ b/book/src/03_3_button.md
@@ -36,8 +36,8 @@ Similarly to turning a `GPIO` into an `output` we can turn it into an `input`. T
 ✅ In the `loop`, add some logic so if the button is not pressed, the LED is lit. If the button is pressed, the LED is off.
 
 [`BOOT` on `GPIO9`]: https://github.com/esp-rs/esp-rust-board#ios
-[into-pull-up-input]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_pull_up_input
-[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
+[into-pull-up-input]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_pull_up_input
+[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
 
 ## Simulation
 

--- a/book/src/03_4_interrupt.md
+++ b/book/src/03_4_interrupt.md
@@ -58,11 +58,11 @@ function, hence it needs to be run inside an `unsafe` block.
 The interrupt handler is defined via the `#[interrupt]` macro.
 Here, the name of the function must match the interrupt.
 
-[listen]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/gpio/trait.Pin.html#method.listen
+[listen]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/trait.Pin.html#method.listen
 [Interrupts]: https://docs.rust-embedded.org/book/start/interrupts.html
 [`critical-section`]: https://crates.io/crates/critical-section
-[possible interrupts]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp32c3/enum.Interrupt.html
-[events]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/gpio/enum.Event.html
+[possible interrupts]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp32c3/enum.Interrupt.html
+[events]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/enum.Event.html
 
 ## Simulation
 

--- a/book/src/03_5_http_client.md
+++ b/book/src/03_5_http_client.md
@@ -92,8 +92,8 @@ To make an HTTP request, we first need to open a socket, and write to it the GET
 {{#include ../../intro/http-client/examples/http-client.rs:socket_close}}
 ```
 
-[timer]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp32c3/systimer/index.html
-[clock]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.0/esp32c3/esp_hal/clock/index.html
+[timer]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp32c3/systimer/index.html
+[clock]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/clock/index.html
 
 ## Simulation
 


### PR DESCRIPTION
I just realized (what I already knew) that we currently only host the current version of the docs. Since we release 0.16.1 the links to 0.16.0 are invalid now. This should fix it.

Not sure what would be a good way to prevent this until we host older versions of the docs.

I don't think GitHub pages support pattern based redirects - probably we just need to update the links whenever we release a new HAL version
