### PR TITLE
Use esp-wifi 0.7.1

### DIFF
--- a/intro/http-client/Cargo.lock
+++ b/intro/http-client/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87071ea2e20ce3ea82cc16e050951fd0e7316111fef610f44bd474c06bbbad7f"
+checksum = "7ba911553329cdd61a1a503d6f71c85f17127447736c3d2522b7ee87d318affd"
 dependencies = [
  "atomic-waker",
  "cfg-if",

--- a/intro/http-client/Cargo.toml
+++ b/intro/http-client/Cargo.toml
@@ -24,7 +24,7 @@ esp-backtrace = { version = "0.13.0", features = [
     "println",
 ] }
 esp-println = { version = "0.10.0", features = ["esp32c3"] }
-esp-wifi = { version = "0.7.0", features = [
+esp-wifi = { version = "0.7.1", features = [
     "esp32c3",
     "wifi-default",
     "utils",


### PR DESCRIPTION
While technically not needed, this bumps the esp-wifi dependency to 0.7.1 to avoid confusion for users