### PR TITLE
docs: update docs.esp-rs.org links to docs.rs

### DIFF
--- a/book/src/03_2_blinky.md
+++ b/book/src/03_2_blinky.md
@@ -41,7 +41,7 @@ We also see that the HAL offers a way to delay execution.
 
 [ESP32-C3-DevKit-RUST-1]:  https://github.com/esp-rs/esp-rust-board
 [LED connected to GPIO 7]: https://github.com/esp-rs/esp-rust-board#pin-layout
-[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
+[into-push-pull-output]: https://docs.rs/esp-hal/0.16.1/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
 [toogle]: https://docs.rs/embedded-hal/0.2.7/embedded_hal/digital/v2/trait.ToggleableOutputPin.html#tymethod.toggle
 [delay-ms]: https://docs.rs/embedded-hal/0.2.7/embedded_hal/blocking/delay/trait.DelayMs.html#tymethod.delay_ms
 

--- a/book/src/03_3_button.md
+++ b/book/src/03_3_button.md
@@ -36,8 +36,8 @@ Similarly to turning a `GPIO` into an `output` we can turn it into an `input`. T
 ✅ In the `loop`, add some logic so if the button is not pressed, the LED is lit. If the button is pressed, the LED is off.
 
 [`BOOT` on `GPIO9`]: https://github.com/esp-rs/esp-rust-board#ios
-[into-pull-up-input]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_pull_up_input
-[into-push-pull-output]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
+[into-pull-up-input]: https://docs.rs/esp-hal/0.16.1/esp_hal/gpio/struct.GpioPin.html#method.into_pull_up_input
+[into-push-pull-output]: https://docs.rs/esp-hal/0.16.1/esp_hal/gpio/struct.GpioPin.html#method.into_push_pull_output
 
 ## Simulation
 

--- a/book/src/03_6_http_client.md
+++ b/book/src/03_6_http_client.md
@@ -96,8 +96,8 @@ To make an HTTP request, we first need to open a socket, and write to it the GET
 {{#include ../../intro/http-client/examples/http-client.rs:socket_close}}
 ```
 
-[timer]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp32c3/systimer/index.html
-[clock]: https://docs.esp-rs.org/esp-hal/esp-hal/0.16.1/esp32c3/esp_hal/clock/index.html
+[timer]: https://docs.rs/esp-hal/0.16.1/esp_hal/systimer/index.html
+[clock]: https://docs.rs/esp-hal/0.16.1/esp_hal/clock/index.html
 
 ## Simulation
 


### PR DESCRIPTION
The `docs.esp-rs.org` domain has expired and now points to unsafe content.
This PR rewrites the broken references to working equivalents.

Each replacement URL was verified to resolve (HTTP 200, follows redirects) before this PR was opened.

The replacements point at `docs.rs/esp-hal/0.16.1/...`. Note: docs.rs builds esp-hal 0.16.1 with the `esp32c6` feature by default, but the GPIO/clock/systimer items linked here have identical signatures across chips, so the docs are functionally equivalent for ESP32-C3 readers.

_Auto-generated as part of a coordinated link cleanup across `esp-rs`._